### PR TITLE
Add more ways to load image data for classification and detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for Flash serve to the `ObjectDetector` ([#1370](https://github.com/PyTorchLightning/lightning-flash/pull/1370))
 
+- Added support for loading `ImageClassificationData` from PIL images with `from_images` ([#1372](https://github.com/PyTorchLightning/lightning-flash/pull/1372))
+
 ### Changed
 
 - Changed the `ImageEmbedder` dependency on VISSL to optional ([#1276](https://github.com/PyTorchLightning/lightning-flash/pull/1276))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for loading `ImageClassificationData` from PIL images with `from_images` ([#1372](https://github.com/PyTorchLightning/lightning-flash/pull/1372))
 
+- Added support for loading `ObjectDetectionData` with `from_numpy`, `from_images`, and `from_tensors` ([#1372](https://github.com/PyTorchLightning/lightning-flash/pull/1372))
+
 ### Changed
 
 - Changed the `ImageEmbedder` dependency on VISSL to optional ([#1276](https://github.com/PyTorchLightning/lightning-flash/pull/1276))

--- a/flash/image/classification/data.py
+++ b/flash/image/classification/data.py
@@ -390,13 +390,13 @@ class ImageClassificationData(DataModule):
     @classmethod
     def from_images(
         cls,
-        train_data: Optional[List[Image.Image]] = None,
+        train_images: Optional[List[Image.Image]] = None,
         train_targets: Optional[Sequence[Any]] = None,
-        val_data: Optional[List[Image.Image]] = None,
+        val_images: Optional[List[Image.Image]] = None,
         val_targets: Optional[Sequence[Any]] = None,
-        test_data: Optional[List[Image.Image]] = None,
+        test_images: Optional[List[Image.Image]] = None,
         test_targets: Optional[Sequence[Any]] = None,
-        predict_data: Optional[List[Image.Image]] = None,
+        predict_images: Optional[List[Image.Image]] = None,
         target_formatter: Optional[TargetFormatter] = None,
         input_cls: Type[Input] = ImageClassificationImageInput,
         transform: INPUT_TRANSFORM_TYPE = ImageClassificationInputTransform,
@@ -412,13 +412,13 @@ class ImageClassificationData(DataModule):
         :ref:`customizing transforms guide <customizing_transforms>`.
 
         Args:
-            train_data: The list of PIL images to use when training.
+            train_images: The list of PIL images to use when training.
             train_targets: The list of targets to use when training.
-            val_data: The list of PIL images to use when validating.
+            val_images: The list of PIL images to use when validating.
             val_targets: The list of targets to use when validating.
-            test_data: The list of PIL images to use when testing.
+            test_images: The list of PIL images to use when testing.
             test_targets: The list of targets to use when testing.
-            predict_data: The list of PIL images to use when predicting.
+            predict_images: The list of PIL images to use when predicting.
             target_formatter: Optionally provide a :class:`~flash.core.data.utilities.classification.TargetFormatter` to
                 control how targets are handled. See :ref:`formatting_classification_targets` for more details.
             input_cls: The :class:`~flash.core.data.io.input.Input` type to use for loading the data.
@@ -440,13 +440,13 @@ class ImageClassificationData(DataModule):
             >>> from flash import Trainer
             >>> from flash.image import ImageClassifier, ImageClassificationData
             >>> datamodule = ImageClassificationData.from_images(
-            ...     train_data=[
+            ...     train_images=[
             ...         Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype="uint8")),
             ...         Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype="uint8")),
             ...         Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype="uint8")),
             ...     ],
             ...     train_targets=["cat", "dog", "cat"],
-            ...     predict_data=[Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype="uint8"))],
+            ...     predict_images=[Image.fromarray(np.random.randint(0, 255, (64, 64, 3), dtype="uint8"))],
             ...     transform_kwargs=dict(image_size=(128, 128)),
             ...     batch_size=2,
             ... )
@@ -465,14 +465,14 @@ class ImageClassificationData(DataModule):
             target_formatter=target_formatter,
         )
 
-        train_input = input_cls(RunningStage.TRAINING, train_data, train_targets, **ds_kw)
+        train_input = input_cls(RunningStage.TRAINING, train_images, train_targets, **ds_kw)
         ds_kw["target_formatter"] = getattr(train_input, "target_formatter", None)
 
         return cls(
             train_input,
-            input_cls(RunningStage.VALIDATING, val_data, val_targets, **ds_kw),
-            input_cls(RunningStage.TESTING, test_data, test_targets, **ds_kw),
-            input_cls(RunningStage.PREDICTING, predict_data, **ds_kw),
+            input_cls(RunningStage.VALIDATING, val_images, val_targets, **ds_kw),
+            input_cls(RunningStage.TESTING, test_images, test_targets, **ds_kw),
+            input_cls(RunningStage.PREDICTING, predict_images, **ds_kw),
             transform=transform,
             transform_kwargs=transform_kwargs,
             **data_module_kwargs,

--- a/flash/image/classification/input.py
+++ b/flash/image/classification/input.py
@@ -24,7 +24,14 @@ from flash.core.data.utilities.paths import filter_valid_files, make_dataset, PA
 from flash.core.data.utilities.samples import to_samples
 from flash.core.integrations.fiftyone.utils import FiftyOneLabelUtilities
 from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, lazy_import, requires
-from flash.image.data import ImageFilesInput, ImageNumpyInput, ImageTensorInput, IMG_EXTENSIONS, NP_EXTENSIONS
+from flash.image.data import (
+    ImageFilesInput,
+    ImageInput,
+    ImageNumpyInput,
+    ImageTensorInput,
+    IMG_EXTENSIONS,
+    NP_EXTENSIONS,
+)
 
 if _FIFTYONE_AVAILABLE:
     fol = lazy_import("fiftyone.core.labels")
@@ -107,6 +114,21 @@ class ImageClassificationNumpyInput(ClassificationInputMixin, ImageNumpyInput):
         if targets is not None:
             self.load_target_metadata(targets, target_formatter=target_formatter)
         return to_samples(array, targets)
+
+    def load_sample(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+        sample = super().load_sample(sample)
+        if DataKeys.TARGET in sample:
+            sample[DataKeys.TARGET] = self.format_target(sample[DataKeys.TARGET])
+        return sample
+
+
+class ImageClassificationImageInput(ClassificationInputMixin, ImageInput):
+    def load_data(
+        self, images: Any, targets: Optional[List[Any]] = None, target_formatter: Optional[TargetFormatter] = None
+    ) -> List[Dict[str, Any]]:
+        if targets is not None:
+            self.load_target_metadata(targets, target_formatter=target_formatter)
+        return to_samples(images, targets)
 
     def load_sample(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         sample = super().load_sample(sample)


### PR DESCRIPTION
## What does this PR do?

Adds:
- `ImageClassificationData.from_images`
- `ObjectDetectionData.from_numpy`
- `ObjectDetectionData.from_images`
- `ObjectDetectionData.from_tensors`

Fixes #1371 

## Before submitting
- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [x] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
