### PR TITLE
Explicitly add fsspec requirement to fix rtd build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
+fsspec


### PR DESCRIPTION
## What does this PR do?

RTD build is failing because it doesn't know to mock out the fsspec library as it's not explicitly given in our requirements. This fixes it.

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
