### PR TITLE
Pets dataset URL is down, change to `pennfudan`

### DIFF
--- a/flash_examples/instance_segmentation.py
+++ b/flash_examples/instance_segmentation.py
@@ -22,12 +22,12 @@ example_requires("image")
 import icedata  # noqa: E402
 
 # 1. Create the DataModule
-data_dir = icedata.pets.load_data()
+data_dir = icedata.pennfudan.load_data()
 
 datamodule = InstanceSegmentationData.from_icedata(
     train_folder=data_dir,
     val_split=0.1,
-    parser=partial(icedata.pets.parser, mask=True),
+    parser=partial(icedata.pennfudan.parser, mask=True),
     batch_size=4,
 )
 


### PR DESCRIPTION
## What does this PR do?

The dataset URL is down for `pets`: https://www.robots.ox.ac.uk/~vgg/data/pets/data. Let's change to `pennfudan` till its' fixed. If I'm not wrong, I've seen it for a day. Let's wait till Friday, and if it isn't fixed, we can merge this PR? cc: @ethanwharris for his opinion. 

```
Sorry - the server was unable to complete your request

This may be because there are already too many connections for the resource you are trying to access. (We limit the number of connections in order to prevent a general Denial-of-Service.)

Please wait a few hours and then try again. Thank you.
```

Important to fix the CI.

Fixes # (issue)

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
