### PR TITLE
Remove `sd2` sound extensions from supported audio extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Removed support for audio files with `sd2` extension, because SoundFile (for sd2 extension) doesn't accept fsspec objects. ([#1409](https://github.com/Lightning-AI/lightning-flash/pull/1409))
+
 ### Fixed
 
 - Fixed a bug where grayscale images were not properly converted to RGB when loaded. ([#1394](https://github.com/PyTorchLightning/lightning-flash/pull/1394))

--- a/flash/audio/classification/data.py
+++ b/flash/audio/classification/data.py
@@ -72,7 +72,7 @@ class AudioClassificationData(DataModule):
         ``.bmp``, ``.pgm``, ``.tif``, ``.tiff``, ``.webp``, and ``.npy``.
         The supported file extensions for raw audio (where spectrograms will be computed automatically) are: ``.aiff``,
         ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``, ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``,
-        ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
+        ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
         The targets can be in any of our
         :ref:`supported classification target formats <formatting_classification_targets>`.
         To learn how to customize the transforms applied for each stage, read our
@@ -184,7 +184,7 @@ class AudioClassificationData(DataModule):
         ``.bmp``, ``.pgm``, ``.tif``, ``.tiff``, ``.webp``, and ``.npy``.
         The supported file extensions for raw audio (where spectrograms will be computed automatically) are: ``.aiff``,
         ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``, ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``,
-        ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
+        ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
         For train, test, and validation data, the folders are expected to contain a sub-folder for each class.
         Here's the required structure:
 
@@ -505,7 +505,7 @@ class AudioClassificationData(DataModule):
         ``.bmp``, ``.pgm``, ``.tif``, ``.tiff``, ``.webp``, and ``.npy``.
         The supported file extensions for raw audio (where spectrograms will be computed automatically) are: ``.aiff``,
         ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``, ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``,
-        ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
+        ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
         The targets will be extracted from the ``target_fields`` in the DataFrame and can be in any of our
         :ref:`supported classification target formats <formatting_classification_targets>`.
         To learn how to customize the transforms applied for each stage, read our
@@ -666,7 +666,7 @@ class AudioClassificationData(DataModule):
         ``.bmp``, ``.pgm``, ``.tif``, ``.tiff``, ``.webp``, and ``.npy``.
         The supported file extensions for raw audio (where spectrograms will be computed automatically) are: ``.aiff``,
         ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``, ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``,
-        ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
+        ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``, ``.wav``, ``.nist``, and ``.wavex``.
         The targets will be extracted from the ``target_fields`` in the CSV files and can be in any of our
         :ref:`supported classification target formats <formatting_classification_targets>`.
         To learn how to customize the transforms applied for each stage, read our

--- a/flash/audio/speech_recognition/data.py
+++ b/flash/audio/speech_recognition/data.py
@@ -60,7 +60,7 @@ class SpeechRecognitionData(DataModule):
         and corresponding lists of targets.
 
         The supported file extensions are: ``.aiff``, ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``,
-        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``,
+        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``,
         ``.wav``, ``.nist``, and ``.wavex``.
         To learn how to customize the transforms applied for each stage, read our
         :ref:`customizing transforms guide <customizing_transforms>`.
@@ -153,7 +153,7 @@ class SpeechRecognitionData(DataModule):
 
         Input audio file paths will be extracted from the ``input_field`` column in the CSV files.
         The supported file extensions are: ``.aiff``, ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``,
-        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``,
+        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``,
         ``.wav``, ``.nist``, and ``.wavex``.
         The targets will be extracted from the ``target_field`` in the CSV files.
         To learn how to customize the transforms applied for each stage, read our
@@ -342,7 +342,7 @@ class SpeechRecognitionData(DataModule):
 
         Input audio file paths will be extracted from the ``input_field`` field in the JSON files.
         The supported file extensions are: ``.aiff``, ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``,
-        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``,
+        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``,
         ``.wav``, ``.nist``, and ``.wavex``.
         The targets will be extracted from the ``target_field`` field in the JSON files.
         To learn how to customize the transforms applied for each stage, read our
@@ -468,7 +468,7 @@ class SpeechRecognitionData(DataModule):
         * A PyTorch Dataset where the ``__getitem__`` returns a dict: ``{"input": file_path, "target": target}``
 
         The supported file extensions are: ``.aiff``, ``.au``, ``.avr``, ``.caf``, ``.flac``, ``.mat``, ``.mat4``,
-        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.sd2``, ``.ircam``, ``.voc``, ``.w64``,
+        ``.mat5``, ``.mpc2k``, ``.ogg``, ``.paf``, ``.pvf``, ``.rf64``, ``.ircam``, ``.voc``, ``.w64``,
         ``.wav``, ``.nist``, and ``.wavex``.
         To learn how to customize the transforms applied for each stage, read our
         :ref:`customizing transforms guide <customizing_transforms>`.

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -165,7 +165,10 @@ def load_spectrogram(file_path: str, sampling_rate: int = 16000, n_fft: int = 40
     """
     loaders = copy.copy(_spectrogram_loaders)
     loaders[AUDIO_EXTENSIONS] = partial(loaders[AUDIO_EXTENSIONS], sampling_rate=sampling_rate, n_fft=n_fft)
-    return load(file_path, loaders)
+    loader = _get_loader(file_path, loaders)
+    # FIXME: Following error is raised while trying to read fsspec object from SoundFile:
+    # RuntimeError: Error opening <fsspec.implementations.local.LocalFileOpener object at 0x100f4ac50>: Format not recognised.
+    return loader(file_path)
 
 
 def load_audio(file_path: str, sampling_rate: int = 16000):

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -46,7 +46,6 @@ AUDIO_EXTENSIONS = (
     ".paf",
     ".pvf",
     ".rf64",
-    ".sd2",
     ".ircam",
     ".voc",
     ".w64",
@@ -165,10 +164,7 @@ def load_spectrogram(file_path: str, sampling_rate: int = 16000, n_fft: int = 40
     """
     loaders = copy.copy(_spectrogram_loaders)
     loaders[AUDIO_EXTENSIONS] = partial(loaders[AUDIO_EXTENSIONS], sampling_rate=sampling_rate, n_fft=n_fft)
-    loader = _get_loader(file_path, loaders)
-    # FIXME: Following error is raised while trying to read fsspec object from SoundFile:
-    # RuntimeError: Error opening <fsspec.implementations.local.LocalFileOpener object at 0x100f4ac50>: Format not recognised.
-    return loader(file_path)
+    return load(file_path, loaders)
 
 
 def load_audio(file_path: str, sampling_rate: int = 16000):


### PR DESCRIPTION
## What does this PR do?

CI is failing, because `SoundFile` (for `sd2` extension) doesn't accept fsspec objects. Following raises an error:

```python
with fsspec.open(file_path) as _file:
    sound_file = SoundFile(_file)
```

Error raised:

```
RuntimeError: Error opening <fsspec.implementations.local.LocalFileOpener object at 0x100f4ac50>: Format not recognised
```

From discussion, we have decided to remove `sd2` extension from supported audio extensions.

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
