### PR TITLE
CI: Update Windows from 2019 to 2022

### DIFF
--- a/.github/workflows/ci-install-pkg.yml
+++ b/.github/workflows/ci-install-pkg.yml
@@ -33,7 +33,7 @@ jobs:
       # max-parallel: 6
       matrix:
         # PyTorch 1.5 is failing on Win and bolts requires torchvision>=0.5
-        os: [ubuntu-20.04, macOS-10.15]  # , windows-2019
+        os: [ubuntu-20.04, macOS-10.15]  # , windows-2022
         # fixme
         python-version: [3.7]  # , 3.8
 

--- a/.github/workflows/ci-notebook.yml
+++ b/.github/workflows/ci-notebook.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-10.15, windows-2019]
+        os: [ubuntu-20.04, macOS-10.15, windows-2022]
         python-version: [3.8]  # 3.6,
     env:
       TEST_ENV: TRUE

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -20,7 +20,7 @@ jobs:
       # max-parallel: 6
       matrix:
         # PyTorch 1.5 is failing on Win and bolts requires torchvision>=0.5
-        os: [ubuntu-20.04, macOS-10.15, windows-2019]
+        os: [ubuntu-20.04, macOS-10.15, windows-2022]
         python-version: [3.7, 3.9]
         requires: ['oldest', 'latest']
         topic: [['core']]


### PR DESCRIPTION
Tries a new Windows https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/