### PR TITLE
CI: Don't move to Lightning Trainer / PL 1.7.0 (temporary fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools<=59.5.0  # Prevent install bug with tensorboard
 numpy
 torch>=1.7.1
 torchmetrics>=0.5.0,!=0.5.1
-pytorch-lightning>=1.3.6
+pytorch-lightning>=1.3.6, <=1.6.5
 pyDeprecate
 pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0


### PR DESCRIPTION
## What does this PR do?

PL 1.7.0 broke the CI (~14 failures), partially because of BC changes and sometimes because of changes in PL 1.7.0. This blocks us from merging PRs, community contributions, and more.

Most of the failures have been fixed, but there are a couple of them remaining and are being addressed in #1410, and other relevant issues in the Lightning repository. We will go back to supporting PL's latest versions once issues are fixed. (partially addresses #1413)

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃

cc: @Borda @ethanwharris @carmocca (for visibility)