### PR TITLE
Video Classification `from_tensors`: test for incorrect data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for `from_tensors` for `VideoClassification` ([#1389](https://github.com/Lightning-AI/lightning-flash/pull/1389))
+
 - Added fine tuning strategies for DeepSpeed (with parameter loading and storing omitted) ([#1377](https://github.com/Lightning-AI/lightning-flash/pull/1377))
 
 - Added `torchvision` as a requirement to `datatype_audio.txt` as it's used for Audio Classification ([#1425](https://github.com/Lightning-AI/lightning-flash/pull/1425))

--- a/tests/video/classification/test_data.py
+++ b/tests/video/classification/test_data.py
@@ -81,13 +81,14 @@ def test_load_data_from_tensors(input_data, input_targets, expected_frames_count
 
 @pytest.mark.skipif(not _VIDEO_AVAILABLE, reason="PyTorchVideo isn't installed.")
 @pytest.mark.parametrize(
-    "input_data, input_targets",
+    "input_data, input_targets, error_type, match",
     [
-        (torch.tensor(1), ["label1"]),
-        (torch.randint(size=(2, 3), low=0, high=255), ["label"]),
-        (torch.randint(size=(2, 3), low=0, high=255), []),
+        (torch.tensor(1), ["label1"], ValueError, "dimension should be"),
+        (torch.randint(size=(2, 3), low=0, high=255), ["label"], ValueError, "dimension should be"),
+        (torch.randint(size=(2, 3), low=0, high=255), [], ValueError, "dimension should be"),
+        (5, [], TypeError, "Expected either a list/tuple"),
     ],
 )
-def test_load_incorrect_data_from_tensors(input_data, input_targets):
-    with pytest.raises(ValueError):
+def test_load_incorrect_data_from_tensors(input_data, input_targets, error_type, match):
+    with pytest.raises(error_type, match=match):
         VideoClassificationData.from_tensors(train_data=input_data, train_targets=input_targets, batch_size=1)

--- a/tests/video/classification/test_data.py
+++ b/tests/video/classification/test_data.py
@@ -67,6 +67,7 @@ def _check_frames(data, expected_frames_count: Union[list, int]):
     [
         ([temp_encoded_tensors(5), temp_encoded_tensors(5)], ["label1", "label2"], [5, 5]),
         ([temp_encoded_tensors(5), temp_encoded_tensors(10)], ["label1", "label2"], [5, 10]),
+        (torch.randint(size=(3, 4, 10, 10), low=0, high=255), ["label1"], [4]),
         (torch.stack((temp_encoded_tensors(5), temp_encoded_tensors(5))), ["label1", "label2"], [5, 5]),
         (torch.stack((temp_encoded_tensors(5),)), ["label1"], [5]),
         (temp_encoded_tensors(5), ["label1"], [5]),
@@ -76,3 +77,17 @@ def test_load_data_from_tensors(input_data, input_targets, expected_frames_count
     datamodule = VideoClassificationData.from_tensors(train_data=input_data, train_targets=input_targets, batch_size=1)
     _check_len_and_values(got=datamodule.labels, expected=input_targets)
     _check_frames(data=datamodule.train_dataset.data, expected_frames_count=expected_frames_count)
+
+
+@pytest.mark.skipif(not _VIDEO_AVAILABLE, reason="PyTorchVideo isn't installed.")
+@pytest.mark.parametrize(
+    "input_data, input_targets",
+    [
+        (torch.tensor(1), ["label1"]),
+        (torch.randint(size=(2, 3), low=0, high=255), ["label"]),
+        (torch.randint(size=(2, 3), low=0, high=255), []),
+    ],
+)
+def test_load_incorrect_data_from_tensors(input_data, input_targets):
+    with pytest.raises(ValueError):
+        VideoClassificationData.from_tensors(train_data=input_data, train_targets=input_targets, batch_size=1)


### PR DESCRIPTION
## What does this PR do?

This PR adds tests to ensure incorrect data raises a relevant error. Also adds a changelog entry for the previous PR on Video Classification

Fixes # (issue)

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [x] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
