### PR TITLE
Improve memory usage

### DIFF
--- a/flash/core/data/io/input.py
+++ b/flash/core/data/io/input.py
@@ -14,7 +14,6 @@
 import functools
 import os
 import sys
-from copy import deepcopy
 from enum import Enum
 from typing import Any, cast, Dict, Iterable, List, Sequence, Tuple, Union
 
@@ -38,6 +37,13 @@ else:
     # ReadTheDocs mocks the `IterableDataset` import so it's type cannot be used as a base for a metaclass, so we
     # replace it here.
     IterableDataset = object
+
+
+def _deepcopy_dict(nested_dict: Any) -> Any:
+    """Utility to deepcopy a nested dict."""
+    if not isinstance(nested_dict, Dict):
+        return nested_dict
+    return {key: value for key, value in nested_dict.items()}
 
 
 class InputFormat(LightningEnum):
@@ -172,7 +178,7 @@ class InputBase(Properties, metaclass=_InputMeta):
 
     def _call_load_sample(self, sample: Any) -> Any:
         # Deepcopy the sample to avoid leaks with complex data structures
-        sample_output = getattr(self, f"{_STAGES_PREFIX[self.running_stage]}_load_sample")(deepcopy(sample))
+        sample_output = getattr(self, f"{_STAGES_PREFIX[self.running_stage]}_load_sample")(_deepcopy_dict(sample))
 
         # Change DataKeys Enum to strings
         if isinstance(sample_output, dict):


### PR DESCRIPTION
## What does this PR do?

Small improvement to avoid deep copying the whole sample (only the nested dicts that need to be copied). This should improve memory usage, particularly with large batches and multiple workers.

May help with #1442

## Before submitting
- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
