### PR TITLE
Raise better error if `icevision` not installed if module isn't found (loading data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the error message to suggest installing `icevision`, if it's not found while loading data ([#1474](https://github.com/Lightning-AI/lightning-flash/pull/1474))
 - Fixed compatibility with `torchmetrics==1.10.0` ([#1469](https://github.com/Lightning-AI/lightning-flash/pull/1469))
 
 

--- a/flash/core/integrations/icevision/data.py
+++ b/flash/core/integrations/icevision/data.py
@@ -20,7 +20,7 @@ from flash.core.data.io.input import DataKeys, Input
 from flash.core.data.utilities.loading import IMG_EXTENSIONS, load_image, NP_EXTENSIONS
 from flash.core.data.utilities.paths import list_valid_files
 from flash.core.integrations.icevision.transforms import from_icevision_record
-from flash.core.utilities.imports import _ICEVISION_AVAILABLE
+from flash.core.utilities.imports import _ICEVISION_AVAILABLE, requires
 
 if _ICEVISION_AVAILABLE:
     from icevision.core.record import BaseRecord
@@ -33,6 +33,7 @@ class IceVisionInput(Input):
     num_classes: int
     labels: list
 
+    @requires("icevision")
     def load_data(
         self,
         root: str,


### PR DESCRIPTION
## What does this PR do?

Addresses #1473. Error after this PR:

```
ModuleNotFoundError: Required dependencies not available. Please run: pip install 'icevision'
```

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [ ] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
