### PR TITLE
fix: datamodule can't load files with square brackets in names

### DIFF
--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -14,6 +14,7 @@
 import copy
 import glob
 from functools import partial
+import re
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import fsspec
@@ -141,7 +142,12 @@ def _get_loader(file_path: str, loaders):
     )
 
 
+WINDOWS_FILE_PATH_RE = re.compile("^[a-zA-Z]:(\\\\[^\\\\]|/[^/]).*")
+
+
 def is_local_path(file_path: str) -> bool:
+    if WINDOWS_FILE_PATH_RE.fullmatch(file_path):
+        return True
     return urlparse(file_path).scheme in ["", "file"]
 
 

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -14,7 +14,9 @@
 import copy
 import glob
 import re
+from os import PathLike
 from functools import partial
+from typing import Union
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import fsspec
@@ -156,8 +158,9 @@ def escape_url(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}{quote(parsed.path)}?{urlencode(parse_qs(parsed.query), doseq=True)}"
 
 
-def escape_file_path(file_path: str) -> str:
-    return glob.escape(file_path) if is_local_path(file_path) else escape_url(file_path)
+def escape_file_path(file_path: Union[str, PathLike]) -> str:
+    file_path_str = str(file_path)
+    return glob.escape(file_path_str) if is_local_path(file_path_str) else escape_url(file_path_str)
 
 
 def load(file_path: str, loaders):

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import glob
 from functools import partial
 
 import fsspec
@@ -141,7 +142,8 @@ def _get_loader(file_path: str, loaders):
 
 def load(file_path: str, loaders):
     loader = _get_loader(file_path, loaders)
-    with fsspec.open(file_path) as file:
+    # escaping file_path to avoid fsspec treating the path as a glob pattern
+    with fsspec.open(glob.escape(file_path)) as file:
         return loader(file)
 
 

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -14,8 +14,8 @@
 import copy
 import glob
 import re
-from os import PathLike
 from functools import partial
+from os import PathLike
 from typing import Union
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -14,7 +14,7 @@
 import copy
 import glob
 from functools import partial
-from urllib.parse import urlparse, urlencode, quote, parse_qs
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import fsspec
 import numpy as np
@@ -142,7 +142,7 @@ def _get_loader(file_path: str, loaders):
 
 
 def is_local_path(file_path: str) -> bool:
-    return urlparse(file_path).scheme in ['', 'file']
+    return urlparse(file_path).scheme in ["", "file"]
 
 
 def escape_url(url: str) -> str:

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -143,6 +143,7 @@ def _get_loader(file_path: str, loaders):
 def load(file_path: str, loaders):
     loader = _get_loader(file_path, loaders)
     # escaping file_path to avoid fsspec treating the path as a glob pattern
+    # fsspec==2022.11.0 ignores `expand=False` in read mode
     with fsspec.open(glob.escape(file_path)) as file:
         return loader(file)
 

--- a/flash/core/data/utilities/loading.py
+++ b/flash/core/data/utilities/loading.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import copy
 import glob
-from functools import partial
 import re
+from functools import partial
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import fsspec

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec
+fsspec==2022.11.0
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec>=2021.6.0, <=2022.7.1
+fsspec>=2021.5.0,<=2022.7.1
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec>2021.06.0, <2022.8.0
+fsspec>2021.6.0, <2022.8.0
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec>2021.6.0, <2022.8.0
+fsspec>=2022.6.0, <=2022.7.1
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec>=2021.5.0,<=2022.7.1
+fsspec[http]>=2021.6.0,<=2022.7.1
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec==2022.11.0
+fsspec>2021.06.0, <2022.8.0
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec[http]>=2021.6.0,<=2022.7.1
+fsspec[http]>=2021.6.1,<=2022.7.1
 lightning-utilities>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.0
 jsonargparse[signatures]>=3.17.0, <=4.9.0
 click>=7.1.2
 protobuf<=3.20.1
-fsspec>=2022.6.0, <=2022.7.1
+fsspec>=2021.6.0, <=2022.7.1
 lightning-utilities>=0.3.0

--- a/tests/core/data/utilities/test_loading.py
+++ b/tests/core/data/utilities/test_loading.py
@@ -86,7 +86,8 @@ def write_tsv(file_path):
     "extension,write",
     [(extension, write_image) for extension in IMG_EXTENSIONS]
     + [(extension, write_numpy) for extension in NP_EXTENSIONS]
-    + [(filename, write_image) for filename in ("image [M].jpeg",)],
+    # it shouldn't try to expand glob patterns in filenames
+    + [(filename, write_image) for filename in ("image [test].jpeg",)],
 )
 def test_load_image(tmpdir, extension, write):
     file_path = os.path.join(tmpdir, f"test{extension}")
@@ -146,6 +147,13 @@ def test_load_data_frame(tmpdir, extension, write):
     [
         pytest.param(
             "https://pl-flash-data.s3.amazonaws.com/images/ant_1.jpg",
+            load_image,
+            Image.Image,
+            marks=pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed."),
+        ),
+        # it shouldn't try to expand glob patterns in URLs
+        pytest.param(
+            "https://39.yt/ant_1 [test].jpg",
             load_image,
             Image.Image,
             marks=pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed."),

--- a/tests/core/data/utilities/test_loading.py
+++ b/tests/core/data/utilities/test_loading.py
@@ -85,7 +85,8 @@ def write_tsv(file_path):
 @pytest.mark.parametrize(
     "extension,write",
     [(extension, write_image) for extension in IMG_EXTENSIONS]
-    + [(extension, write_numpy) for extension in NP_EXTENSIONS],
+    + [(extension, write_numpy) for extension in NP_EXTENSIONS]
+    + [(filename, write_image) for filename in ("image [M].jpeg",)],
 )
 def test_load_image(tmpdir, extension, write):
     file_path = os.path.join(tmpdir, f"test{extension}")

--- a/tests/core/data/utilities/test_loading.py
+++ b/tests/core/data/utilities/test_loading.py
@@ -153,7 +153,7 @@ def test_load_data_frame(tmpdir, extension, write):
         ),
         # it shouldn't try to expand glob patterns in URLs
         pytest.param(
-            "https://39.yt/ant_1 [test].jpg",
+            "https://pl-flash-data.s3.amazonaws.com/images/ant_1 [test].jpg",
             load_image,
             Image.Image,
             marks=pytest.mark.skipif(not _IMAGE_TESTING, reason="image libraries aren't installed."),


### PR DESCRIPTION
## What does this PR do?

This PR makes `flash.DataModule` support files with square brackets (and other glob patterns) in the filenames. More details are in #1500.

Closes #1500.

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
