### PR TITLE
docs: fix typo in tabularregression docstring

### DIFF
--- a/flash/tabular/regression/model.py
+++ b/flash/tabular/regression/model.py
@@ -40,10 +40,10 @@ class TabularRegressor(RegressionAdapterTask):
         parameters: The parameters computed from the training data (can be obtained from the ``parameters`` attribute of
             the ``TabularRegressionData`` object containing your training data).
         embedding_sizes: List of (num_classes, emb_dim) to form categorical embeddings.
-        cat_dims: Number of distinct values for each categorical column
-        num_features: Number of columns in table
-        backbone: name of the model to use
-        loss_fn: Loss function for training, defaults to cross entropy.
+        cat_dims: Number of distinct values for each categorical column.
+        num_features: Number of columns in table.
+        backbone: name of the model to use.
+        loss_fn: Loss function for training, defaults to mean squared error.
         optimizer: Optimizer to use for training.
         lr_scheduler: The LR scheduler to use during training.
         metrics: Metrics to compute for training and evaluation. Can either be an metric from the `torchmetrics`


### PR DESCRIPTION
## What does this PR do?

Fixes a micro-typo in the docstring of the tabular regression model. 
Also adds missing full stops. 

Fixes # (issue)

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
